### PR TITLE
Translate hero section

### DIFF
--- a/src/components/Layout/HomeContent.js
+++ b/src/components/Layout/HomeContent.js
@@ -131,7 +131,7 @@ export function HomeContent() {
             React
           </h1>
           <p className="text-4xl font-display max-w-lg md:max-w-full py-1 text-center text-secondary dark:text-primary-dark leading-snug self-center">
-            The library for web and native user interfaces
+            Die Bibliothek für webbasierte und native Benutzeroberflächen
           </p>
           <div className="mt-5 self-center flex gap-2 w-full sm:w-auto flex-col sm:flex-row">
             <ButtonLink
@@ -139,16 +139,16 @@ export function HomeContent() {
               type="primary"
               size="lg"
               className="w-full sm:w-auto justify-center"
-              label="Learn React">
-              Learn React
+              label="Lerne React">
+              Lerne React
             </ButtonLink>
             <ButtonLink
               href={'/reference/react'}
               type="secondary"
               size="lg"
               className="w-full sm:w-auto justify-center"
-              label="API Reference">
-              API Reference
+              label="API-Referenz">
+              API-Referenz
             </ButtonLink>
           </div>
         </div>


### PR DESCRIPTION
I followed the recommendation to leave out most of the UI translations to the end in #317 but I think it would be great to translate the hero section on the home page, so that visitors immediately see that they are on the german version.

